### PR TITLE
Feature: Add Base for all tasks and services to inherit from

### DIFF
--- a/lib/rails_tasker/base.rb
+++ b/lib/rails_tasker/base.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_tasker/serviceable'
+
+module RailsTasker
+  class Base
+    include Serviceable
+  end
+end

--- a/lib/rails_tasker/serviceable.rb
+++ b/lib/rails_tasker/serviceable.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RailsTasker
+  module Serviceable
+    def self.included(klass)
+      klass.extend ClassMethods
+    end
+
+    def call
+      raise NotImplementedError
+    end
+
+    module ClassMethods
+      def call
+        new.call
+      end
+    end
+  end
+end

--- a/spec/rails_tasker/base_spec.rb
+++ b/spec/rails_tasker/base_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_tasker/base'
+require 'rails_tasker/serviceable'
+
+RSpec.describe RailsTasker::Base do
+  it 'includes Serviceable' do
+    expect(described_class.ancestors).to include RailsTasker::Serviceable
+  end
+end

--- a/spec/rails_tasker/serviceable_spec.rb
+++ b/spec/rails_tasker/serviceable_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_tasker/serviceable'
+
+RSpec.describe RailsTasker::Serviceable do
+  let(:klass) do
+    Class.new do
+      include RailsTasker::Serviceable
+    end
+  end
+  let(:instance) { klass.new }
+
+  describe '.included' do
+    before { allow(klass).to receive(:extend) }
+
+    it 'extends the class with ClassMethods' do
+      RailsTasker::Serviceable.included klass
+      expect(klass).to have_received(:extend).with(
+        RailsTasker::Serviceable::ClassMethods
+      ).once
+    end
+  end
+
+  describe '#call' do
+    it 'raises NotImplementedError' do
+      expect { instance.call }.to raise_error NotImplementedError
+    end
+  end
+
+  describe 'ClassMethods' do
+    describe '.call' do
+      before do
+        allow(klass).to receive(:new).and_return instance
+        allow(instance).to receive(:call)
+      end
+  
+      it 'creates new instance' do
+        klass.call
+        expect(klass).to have_received(:new).once
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Base for all tasks and services to inherit from.

Adds `RailsTasker::Base` and `RailsTasker::Serviceable`