### PR TITLE
Feature: Add RailsTasker::TaskFile

### DIFF
--- a/lib/rails_tasker/task_file.rb
+++ b/lib/rails_tasker/task_file.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_tasker/models/task'
+
+module RailsTasker
+  class TaskFile
+    def initialize(filename: '')
+      @filename = filename
+      @timestamp, @task_name = parse_filename
+    end
+
+    attr_reader :filename, :timestamp, :task_name
+
+    def pending?
+      !timestamp.empty? && !Task.completed_task?(version: timestamp)
+    end
+
+    private
+
+    def parse_filename
+      timestamp = ''
+      task_name = ''
+
+      /(\d+)_(.+)\.rb/.match(Pathname(@filename).basename.to_s) do |m|
+        timestamp = m[1]
+        task_name = m[2]
+      end
+
+      [timestamp, task_name]
+    end
+  end
+end

--- a/spec/rails_tasker/task_file_spec.rb
+++ b/spec/rails_tasker/task_file_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_tasker/task_file'
+require 'rails_tasker/models/task'
+
+RSpec.describe RailsTasker::TaskFile do
+  let(:examples_path) { '../../examples/lib/rails_tasker/tasks' }
+  let(:filename) { "#{examples_path}/1234_example_task.rb" }
+  let(:instance) { described_class.new(filename: filename) }
+
+  describe '#filename' do
+    it 'returns the expected result' do
+      expect(instance.filename).to eq filename
+    end
+  end
+
+  describe '#timestamp' do
+    it 'returns the expected result' do
+      expect(instance.timestamp).to eq '1234'
+    end
+  end
+
+  describe '#task_name' do
+    it 'returns the expected result' do
+      expect(instance.task_name).to eq 'example_task'
+    end
+  end
+
+  describe '#pending?' do
+    let(:is_completed) { false }
+
+    before do
+      allow(RailsTasker::Task).to receive(:completed_task?).and_return is_completed
+    end
+
+    it 'returns true' do
+      expect(instance.pending?).to eq true
+    end
+
+    context 'timestamp is empty' do
+      let(:filename) { "#{examples_path}/example_without_timestamp_task.rb" }
+
+      it 'returns false' do
+        expect(instance.pending?).to eq false
+      end
+    end
+
+    context 'the task has been completed' do
+      let(:is_completed) { true }
+
+      it 'returns false' do
+        expect(instance.pending?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `RailsTasker::TaskFile` that can be used to represent an task that can be ran.